### PR TITLE
Remove .ipynb_checkpoints from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,5 @@
 .coverage
 htmlcov/
 config.ini
-.ipynb_checkpoints/
 dist
 libmozdata.egg-info


### PR DESCRIPTION
Not needed anymore since the iPython notebooks are now in a separate repo.