### PR TITLE
Calc changes additions/deletions per patches

### DIFF
--- a/libmozdata/patchanalysis.py
+++ b/libmozdata/patchanalysis.py
@@ -161,6 +161,8 @@ def patch_analysis(patch, authors, reviewers, creation_date=utils.get_date_ymd('
     info = {
         'changes_size': 0,
         'test_changes_size': 0,
+        'changes_add': 0,
+        'changes_del': 0,
         'modules_num': 0,
         'code_churn_overall': 0,
         'code_churn_last_3_releases': 0,
@@ -174,6 +176,15 @@ def patch_analysis(patch, authors, reviewers, creation_date=utils.get_date_ymd('
     for diff in whatthepatch.parse_patch(patch):
         old_path = diff.header.old_path[2:] if diff.header.old_path.startswith('a/') else diff.header.old_path
         new_path = diff.header.new_path[2:] if diff.header.new_path.startswith('b/') else diff.header.new_path
+
+        # Calc changes additions & deletions
+        counts = [(
+            old is None and new is not None,
+            new is None and old is not None
+        ) for old, new, _ in diff.changes]
+        counts = list(zip(*counts))  # inverse zip
+        info['changes_add'] += sum(counts[0])
+        info['changes_del'] += sum(counts[1])
 
         # TODO: Split C/C++, Rust, Java, JavaScript, build system changes
         if _is_test(new_path):

--- a/tests/patches/1007402.json
+++ b/tests/patches/1007402.json
@@ -1,5 +1,7 @@
 {
     "8447556": {
+        "changes_add": 273,
+        "changes_del": 352,
         "changes_size": 1020,
         "code_churn_last_3_releases": 316,
         "code_churn_overall": 2465,
@@ -13,6 +15,8 @@
         "url": "https://bugzilla.mozilla.org/attachment.cgi?id=8447556"
     },
     "8447557": {
+        "changes_add": 9,
+        "changes_del": 0,
         "changes_size": 15,
         "code_churn_last_3_releases": 0,
         "code_churn_overall": 0,

--- a/tests/patches/1007402.json
+++ b/tests/patches/1007402.json
@@ -1,0 +1,28 @@
+{
+    "8447556": {
+        "changes_size": 1020,
+        "code_churn_last_3_releases": 316,
+        "code_churn_overall": 2465,
+        "developer_familiarity_last_3_releases": 4,
+        "developer_familiarity_overall": 4,
+        "modules_num": 6,
+        "reviewer_familiarity_last_3_releases": 15,
+        "reviewer_familiarity_overall": 266,
+        "source": "attachment",
+        "test_changes_size": 445,
+        "url": "https://bugzilla.mozilla.org/attachment.cgi?id=8447556"
+    },
+    "8447557": {
+        "changes_size": 15,
+        "code_churn_last_3_releases": 0,
+        "code_churn_overall": 0,
+        "developer_familiarity_last_3_releases": 0,
+        "developer_familiarity_overall": 0,
+        "modules_num": 0,
+        "reviewer_familiarity_last_3_releases": 0,
+        "reviewer_familiarity_overall": 0,
+        "source": "attachment",
+        "test_changes_size": 0,
+        "url": "https://bugzilla.mozilla.org/attachment.cgi?id=8447557"
+    }
+}

--- a/tests/patches/1021265.json
+++ b/tests/patches/1021265.json
@@ -1,5 +1,7 @@
 {
     "0b298d91fbdd": {
+        "changes_add": 1,
+        "changes_del": 1,
         "changes_size": 18,
         "code_churn_last_3_releases": 28,
         "code_churn_overall": 298,
@@ -13,6 +15,8 @@
         "url": "https://hg.mozilla.org/mozilla-central/rev/0b298d91fbdd"
     },
     "1b07e2892e9d": {
+        "changes_add": 10,
+        "changes_del": 0,
         "changes_size": 45,
         "code_churn_last_3_releases": 28,
         "code_churn_overall": 299,
@@ -26,6 +30,8 @@
         "url": "https://hg.mozilla.org/mozilla-central/rev/1b07e2892e9d"
     },
     "3d0169c5795f": {
+        "changes_add": 18,
+        "changes_del": 5,
         "changes_size": 92,
         "code_churn_last_3_releases": 62,
         "code_churn_overall": 863,
@@ -39,6 +45,8 @@
         "url": "https://hg.mozilla.org/mozilla-central/rev/3d0169c5795f"
     },
     "96f0df721845": {
+        "changes_add": 1,
+        "changes_del": 1,
         "changes_size": 18,
         "code_churn_last_3_releases": 32,
         "code_churn_overall": 303,

--- a/tests/patches/1021265.json
+++ b/tests/patches/1021265.json
@@ -1,0 +1,54 @@
+{
+    "0b298d91fbdd": {
+        "changes_size": 18,
+        "code_churn_last_3_releases": 28,
+        "code_churn_overall": 298,
+        "developer_familiarity_last_3_releases": 4,
+        "developer_familiarity_overall": 15,
+        "modules_num": 1,
+        "reviewer_familiarity_last_3_releases": 28,
+        "reviewer_familiarity_overall": 298,
+        "source": "mercurial",
+        "test_changes_size": 0,
+        "url": "https://hg.mozilla.org/mozilla-central/rev/0b298d91fbdd"
+    },
+    "1b07e2892e9d": {
+        "changes_size": 45,
+        "code_churn_last_3_releases": 28,
+        "code_churn_overall": 299,
+        "developer_familiarity_last_3_releases": 5,
+        "developer_familiarity_overall": 16,
+        "modules_num": 1,
+        "reviewer_familiarity_last_3_releases": 2,
+        "reviewer_familiarity_overall": 11,
+        "source": "mercurial",
+        "test_changes_size": 0,
+        "url": "https://hg.mozilla.org/mozilla-central/rev/1b07e2892e9d"
+    },
+    "3d0169c5795f": {
+        "changes_size": 92,
+        "code_churn_last_3_releases": 62,
+        "code_churn_overall": 863,
+        "developer_familiarity_last_3_releases": 5,
+        "developer_familiarity_overall": 23,
+        "modules_num": 2,
+        "reviewer_familiarity_last_3_releases": 6,
+        "reviewer_familiarity_overall": 16,
+        "source": "mercurial",
+        "test_changes_size": 0,
+        "url": "https://hg.mozilla.org/mozilla-central/rev/3d0169c5795f"
+    },
+    "96f0df721845": {
+        "changes_size": 18,
+        "code_churn_last_3_releases": 32,
+        "code_churn_overall": 303,
+        "developer_familiarity_last_3_releases": 3,
+        "developer_familiarity_overall": 12,
+        "modules_num": 1,
+        "reviewer_familiarity_last_3_releases": 0,
+        "reviewer_familiarity_overall": 0,
+        "source": "mercurial",
+        "test_changes_size": 0,
+        "url": "https://hg.mozilla.org/mozilla-central/rev/96f0df721845"
+    }
+}

--- a/tests/patches/1029098.json
+++ b/tests/patches/1029098.json
@@ -1,0 +1,15 @@
+{
+    "d41a6d09ccd6": {
+        "changes_size": 94,
+        "code_churn_last_3_releases": 15,
+        "code_churn_overall": 277,
+        "developer_familiarity_last_3_releases": 8,
+        "developer_familiarity_overall": 81,
+        "modules_num": 1,
+        "reviewer_familiarity_last_3_releases": 0,
+        "reviewer_familiarity_overall": 9,
+        "source": "mercurial",
+        "test_changes_size": 97,
+        "url": "https://hg.mozilla.org/mozilla-central/rev/d41a6d09ccd6"
+    }
+}

--- a/tests/patches/1029098.json
+++ b/tests/patches/1029098.json
@@ -1,5 +1,7 @@
 {
     "d41a6d09ccd6": {
+        "changes_add": 82,
+        "changes_del": 8,
         "changes_size": 94,
         "code_churn_last_3_releases": 15,
         "code_churn_overall": 277,

--- a/tests/patches/1220307.json
+++ b/tests/patches/1220307.json
@@ -1,0 +1,41 @@
+{
+    "6126c53203f8": {
+        "changes_size": 40,
+        "code_churn_last_3_releases": 13,
+        "code_churn_overall": 14,
+        "developer_familiarity_last_3_releases": 4,
+        "developer_familiarity_overall": 4,
+        "modules_num": 1,
+        "reviewer_familiarity_last_3_releases": 1,
+        "reviewer_familiarity_overall": 1,
+        "source": "mercurial",
+        "test_changes_size": 0,
+        "url": "https://hg.mozilla.org/mozilla-central/rev/6126c53203f8"
+    },
+    "933b5260480f": {
+        "changes_size": 27,
+        "code_churn_last_3_releases": 15,
+        "code_churn_overall": 52,
+        "developer_familiarity_last_3_releases": 0,
+        "developer_familiarity_overall": 0,
+        "modules_num": 1,
+        "reviewer_familiarity_last_3_releases": 0,
+        "reviewer_familiarity_overall": 1,
+        "source": "mercurial",
+        "test_changes_size": 0,
+        "url": "https://hg.mozilla.org/mozilla-central/rev/933b5260480f"
+    },
+    "c17c6b68112c": {
+        "changes_size": 0,
+        "code_churn_last_3_releases": 5,
+        "code_churn_overall": 13,
+        "developer_familiarity_last_3_releases": 1,
+        "developer_familiarity_overall": 1,
+        "modules_num": 1,
+        "reviewer_familiarity_last_3_releases": 0,
+        "reviewer_familiarity_overall": 0,
+        "source": "mercurial",
+        "test_changes_size": 50,
+        "url": "https://hg.mozilla.org/mozilla-central/rev/c17c6b68112c"
+    }
+}

--- a/tests/patches/1220307.json
+++ b/tests/patches/1220307.json
@@ -1,5 +1,7 @@
 {
     "6126c53203f8": {
+        "changes_add": 4,
+        "changes_del": 0,
         "changes_size": 40,
         "code_churn_last_3_releases": 13,
         "code_churn_overall": 14,
@@ -13,6 +15,8 @@
         "url": "https://hg.mozilla.org/mozilla-central/rev/6126c53203f8"
     },
     "933b5260480f": {
+        "changes_add": 17,
+        "changes_del": 0,
         "changes_size": 27,
         "code_churn_last_3_releases": 15,
         "code_churn_overall": 52,
@@ -26,6 +30,8 @@
         "url": "https://hg.mozilla.org/mozilla-central/rev/933b5260480f"
     },
     "c17c6b68112c": {
+        "changes_add": 6,
+        "changes_del": 6,
         "changes_size": 0,
         "code_churn_last_3_releases": 5,
         "code_churn_overall": 13,

--- a/tests/patches/1276850.json
+++ b/tests/patches/1276850.json
@@ -1,0 +1,15 @@
+{
+    "da10eecd0e76": {
+        "changes_size": 40,
+        "code_churn_last_3_releases": 21,
+        "code_churn_overall": 26,
+        "developer_familiarity_last_3_releases": 0,
+        "developer_familiarity_overall": 0,
+        "modules_num": 1,
+        "reviewer_familiarity_last_3_releases": 21,
+        "reviewer_familiarity_overall": 26,
+        "source": "mercurial",
+        "test_changes_size": 0,
+        "url": "https://hg.mozilla.org/mozilla-central/rev/da10eecd0e76"
+    }
+}

--- a/tests/patches/1276850.json
+++ b/tests/patches/1276850.json
@@ -1,5 +1,7 @@
 {
     "da10eecd0e76": {
+        "changes_add": 0,
+        "changes_del": 4,
         "changes_size": 40,
         "code_churn_last_3_releases": 21,
         "code_churn_overall": 26,

--- a/tests/patches/384458.json
+++ b/tests/patches/384458.json
@@ -1,0 +1,67 @@
+{
+    "0d05e6a1bdc2": {
+        "changes_size": 72,
+        "code_churn_last_3_releases": 5,
+        "code_churn_overall": 25,
+        "developer_familiarity_last_3_releases": 2,
+        "developer_familiarity_overall": 2,
+        "modules_num": 1,
+        "reviewer_familiarity_last_3_releases": 0,
+        "reviewer_familiarity_overall": 0,
+        "source": "mercurial",
+        "test_changes_size": 0,
+        "url": "https://hg.mozilla.org/mozilla-central/rev/0d05e6a1bdc2"
+    },
+    "1c86ba5d7a5b": {
+        "changes_size": 35,
+        "code_churn_last_3_releases": 57,
+        "code_churn_overall": 406,
+        "developer_familiarity_last_3_releases": 8,
+        "developer_familiarity_overall": 13,
+        "modules_num": 3,
+        "reviewer_familiarity_last_3_releases": 0,
+        "reviewer_familiarity_overall": 0,
+        "source": "mercurial",
+        "test_changes_size": 462,
+        "url": "https://hg.mozilla.org/mozilla-central/rev/1c86ba5d7a5b"
+    },
+    "73176395400e": {
+        "changes_size": 1227,
+        "code_churn_last_3_releases": 354,
+        "code_churn_overall": 3616,
+        "developer_familiarity_last_3_releases": 20,
+        "developer_familiarity_overall": 63,
+        "modules_num": 3,
+        "reviewer_familiarity_last_3_releases": 0,
+        "reviewer_familiarity_overall": 1,
+        "source": "mercurial",
+        "test_changes_size": 0,
+        "url": "https://hg.mozilla.org/mozilla-central/rev/73176395400e"
+    },
+    "b94fedbf48b1": {
+        "changes_size": 1060,
+        "code_churn_last_3_releases": 34,
+        "code_churn_overall": 353,
+        "developer_familiarity_last_3_releases": 10,
+        "developer_familiarity_overall": 41,
+        "modules_num": 1,
+        "reviewer_familiarity_last_3_releases": 0,
+        "reviewer_familiarity_overall": 0,
+        "source": "mercurial",
+        "test_changes_size": 0,
+        "url": "https://hg.mozilla.org/mozilla-central/rev/b94fedbf48b1"
+    },
+    "de5d300e4687": {
+        "changes_size": 358,
+        "code_churn_last_3_releases": 363,
+        "code_churn_overall": 3805,
+        "developer_familiarity_last_3_releases": 11,
+        "developer_familiarity_overall": 43,
+        "modules_num": 3,
+        "reviewer_familiarity_last_3_releases": 0,
+        "reviewer_familiarity_overall": 1,
+        "source": "mercurial",
+        "test_changes_size": 0,
+        "url": "https://hg.mozilla.org/mozilla-central/rev/de5d300e4687"
+    }
+}

--- a/tests/patches/384458.json
+++ b/tests/patches/384458.json
@@ -1,5 +1,7 @@
 {
     "0d05e6a1bdc2": {
+        "changes_add": 10,
+        "changes_del": 0,
         "changes_size": 72,
         "code_churn_last_3_releases": 5,
         "code_churn_overall": 25,
@@ -13,6 +15,8 @@
         "url": "https://hg.mozilla.org/mozilla-central/rev/0d05e6a1bdc2"
     },
     "1c86ba5d7a5b": {
+        "changes_add": 251,
+        "changes_del": 29,
         "changes_size": 35,
         "code_churn_last_3_releases": 57,
         "code_churn_overall": 406,
@@ -26,6 +30,8 @@
         "url": "https://hg.mozilla.org/mozilla-central/rev/1c86ba5d7a5b"
     },
     "73176395400e": {
+        "changes_add": 718,
+        "changes_del": 32,
         "changes_size": 1227,
         "code_churn_last_3_releases": 354,
         "code_churn_overall": 3616,
@@ -39,6 +45,8 @@
         "url": "https://hg.mozilla.org/mozilla-central/rev/73176395400e"
     },
     "b94fedbf48b1": {
+        "changes_add": 497,
+        "changes_del": 408,
         "changes_size": 1060,
         "code_churn_last_3_releases": 34,
         "code_churn_overall": 353,
@@ -52,6 +60,8 @@
         "url": "https://hg.mozilla.org/mozilla-central/rev/b94fedbf48b1"
     },
     "de5d300e4687": {
+        "changes_add": 65,
+        "changes_del": 22,
         "changes_size": 358,
         "code_churn_last_3_releases": 363,
         "code_churn_overall": 3805,

--- a/tests/patches/679509.json
+++ b/tests/patches/679509.json
@@ -1,5 +1,7 @@
 {
     "38f53f45bbf4": {
+        "changes_add": 92,
+        "changes_del": 8,
         "changes_size": 145,
         "code_churn_last_3_releases": 294,
         "code_churn_overall": 1811,
@@ -13,6 +15,8 @@
         "url": "https://hg.mozilla.org/mozilla-central/rev/38f53f45bbf4"
     },
     "40f077f9c4a2": {
+        "changes_add": 16,
+        "changes_del": 41,
         "changes_size": 101,
         "code_churn_last_3_releases": 22,
         "code_churn_overall": 34,
@@ -26,6 +30,8 @@
         "url": "https://hg.mozilla.org/mozilla-central/rev/40f077f9c4a2"
     },
     "8c59e49aea63": {
+        "changes_add": 37,
+        "changes_del": 0,
         "changes_size": 17,
         "code_churn_last_3_releases": 9,
         "code_churn_overall": 11,
@@ -39,6 +45,8 @@
         "url": "https://hg.mozilla.org/mozilla-central/rev/8c59e49aea63"
     },
     "97f2fc986824": {
+        "changes_add": 4,
+        "changes_del": 16,
         "changes_size": 84,
         "code_churn_last_3_releases": 9,
         "code_churn_overall": 18,

--- a/tests/patches/679509.json
+++ b/tests/patches/679509.json
@@ -1,0 +1,54 @@
+{
+    "38f53f45bbf4": {
+        "changes_size": 145,
+        "code_churn_last_3_releases": 294,
+        "code_churn_overall": 1811,
+        "developer_familiarity_last_3_releases": 40,
+        "developer_familiarity_overall": 113,
+        "modules_num": 2,
+        "reviewer_familiarity_last_3_releases": 41,
+        "reviewer_familiarity_overall": 50,
+        "source": "mercurial",
+        "test_changes_size": 36,
+        "url": "https://hg.mozilla.org/mozilla-central/rev/38f53f45bbf4"
+    },
+    "40f077f9c4a2": {
+        "changes_size": 101,
+        "code_churn_last_3_releases": 22,
+        "code_churn_overall": 34,
+        "developer_familiarity_last_3_releases": 3,
+        "developer_familiarity_overall": 3,
+        "modules_num": 1,
+        "reviewer_familiarity_last_3_releases": 22,
+        "reviewer_familiarity_overall": 34,
+        "source": "mercurial",
+        "test_changes_size": 36,
+        "url": "https://hg.mozilla.org/mozilla-central/rev/40f077f9c4a2"
+    },
+    "8c59e49aea63": {
+        "changes_size": 17,
+        "code_churn_last_3_releases": 9,
+        "code_churn_overall": 11,
+        "developer_familiarity_last_3_releases": 0,
+        "developer_familiarity_overall": 0,
+        "modules_num": 1,
+        "reviewer_familiarity_last_3_releases": 0,
+        "reviewer_familiarity_overall": 0,
+        "source": "mercurial",
+        "test_changes_size": 36,
+        "url": "https://hg.mozilla.org/mozilla-central/rev/8c59e49aea63"
+    },
+    "97f2fc986824": {
+        "changes_size": 84,
+        "code_churn_last_3_releases": 9,
+        "code_churn_overall": 18,
+        "developer_familiarity_last_3_releases": 0,
+        "developer_familiarity_overall": 0,
+        "modules_num": 1,
+        "reviewer_familiarity_last_3_releases": 0,
+        "reviewer_familiarity_overall": 0,
+        "source": "mercurial",
+        "test_changes_size": 0,
+        "url": "https://hg.mozilla.org/mozilla-central/rev/97f2fc986824"
+    }
+}

--- a/tests/patches/699633.json
+++ b/tests/patches/699633.json
@@ -1,0 +1,15 @@
+{
+    "936643625d71": {
+        "changes_size": 177,
+        "code_churn_last_3_releases": 66,
+        "code_churn_overall": 66,
+        "developer_familiarity_last_3_releases": 28,
+        "developer_familiarity_overall": 28,
+        "modules_num": 1,
+        "reviewer_familiarity_last_3_releases": 0,
+        "reviewer_familiarity_overall": 0,
+        "source": "mercurial",
+        "test_changes_size": 35,
+        "url": "https://hg.mozilla.org/mozilla-central/rev/936643625d71"
+    }
+}

--- a/tests/patches/699633.json
+++ b/tests/patches/699633.json
@@ -1,5 +1,7 @@
 {
     "936643625d71": {
+        "changes_add": 69,
+        "changes_del": 43,
         "changes_size": 177,
         "code_churn_last_3_releases": 66,
         "code_churn_overall": 66,

--- a/tests/patches/701875.json
+++ b/tests/patches/701875.json
@@ -1,0 +1,28 @@
+{
+    "3f0b94325b80": {
+        "changes_size": 165,
+        "code_churn_last_3_releases": 330,
+        "code_churn_overall": 2312,
+        "developer_familiarity_last_3_releases": 7,
+        "developer_familiarity_overall": 61,
+        "modules_num": 4,
+        "reviewer_familiarity_last_3_releases": 0,
+        "reviewer_familiarity_overall": 0,
+        "source": "mercurial",
+        "test_changes_size": 0,
+        "url": "https://hg.mozilla.org/mozilla-central/rev/3f0b94325b80"
+    },
+    "7ae3089be8a5": {
+        "changes_size": 29,
+        "code_churn_last_3_releases": 196,
+        "code_churn_overall": 1458,
+        "developer_familiarity_last_3_releases": 5,
+        "developer_familiarity_overall": 25,
+        "modules_num": 1,
+        "reviewer_familiarity_last_3_releases": 196,
+        "reviewer_familiarity_overall": 1458,
+        "source": "mercurial",
+        "test_changes_size": 0,
+        "url": "https://hg.mozilla.org/mozilla-central/rev/7ae3089be8a5"
+    }
+}

--- a/tests/patches/701875.json
+++ b/tests/patches/701875.json
@@ -1,5 +1,7 @@
 {
     "3f0b94325b80": {
+        "changes_add": 15,
+        "changes_del": 7,
         "changes_size": 165,
         "code_churn_last_3_releases": 330,
         "code_churn_overall": 2312,
@@ -13,6 +15,8 @@
         "url": "https://hg.mozilla.org/mozilla-central/rev/3f0b94325b80"
     },
     "7ae3089be8a5": {
+        "changes_add": 2,
+        "changes_del": 2,
         "changes_size": 29,
         "code_churn_last_3_releases": 196,
         "code_churn_overall": 1458,

--- a/tests/patches/721760.json
+++ b/tests/patches/721760.json
@@ -1,0 +1,28 @@
+{
+    "2ef72ec44da3": {
+        "changes_size": 44,
+        "code_churn_last_3_releases": 1,
+        "code_churn_overall": 2,
+        "developer_familiarity_last_3_releases": 0,
+        "developer_familiarity_overall": 0,
+        "modules_num": 1,
+        "reviewer_familiarity_last_3_releases": 0,
+        "reviewer_familiarity_overall": 0,
+        "source": "mercurial",
+        "test_changes_size": 0,
+        "url": "https://hg.mozilla.org/mozilla-central/rev/2ef72ec44da3"
+    },
+    "66b36a145f89": {
+        "changes_size": 172,
+        "code_churn_last_3_releases": 24,
+        "code_churn_overall": 36,
+        "developer_familiarity_last_3_releases": 17,
+        "developer_familiarity_overall": 28,
+        "modules_num": 1,
+        "reviewer_familiarity_last_3_releases": 6,
+        "reviewer_familiarity_overall": 13,
+        "source": "mercurial",
+        "test_changes_size": 0,
+        "url": "https://hg.mozilla.org/mozilla-central/rev/66b36a145f89"
+    }
+}

--- a/tests/patches/721760.json
+++ b/tests/patches/721760.json
@@ -1,5 +1,7 @@
 {
     "2ef72ec44da3": {
+        "changes_add": 12,
+        "changes_del": 11,
         "changes_size": 44,
         "code_churn_last_3_releases": 1,
         "code_churn_overall": 2,
@@ -13,6 +15,8 @@
         "url": "https://hg.mozilla.org/mozilla-central/rev/2ef72ec44da3"
     },
     "66b36a145f89": {
+        "changes_add": 35,
+        "changes_del": 11,
         "changes_size": 172,
         "code_churn_last_3_releases": 24,
         "code_churn_overall": 36,

--- a/tests/patches/799266.json
+++ b/tests/patches/799266.json
@@ -1,0 +1,15 @@
+{
+    "53ae9eb476e9": {
+        "changes_size": 104,
+        "code_churn_last_3_releases": 37,
+        "code_churn_overall": 355,
+        "developer_familiarity_last_3_releases": 5,
+        "developer_familiarity_overall": 36,
+        "modules_num": 1,
+        "reviewer_familiarity_last_3_releases": 0,
+        "reviewer_familiarity_overall": 1,
+        "source": "mercurial",
+        "test_changes_size": 0,
+        "url": "https://hg.mozilla.org/mozilla-central/rev/53ae9eb476e9"
+    }
+}

--- a/tests/patches/799266.json
+++ b/tests/patches/799266.json
@@ -1,5 +1,7 @@
 {
     "53ae9eb476e9": {
+        "changes_add": 33,
+        "changes_del": 1,
         "changes_size": 104,
         "code_churn_last_3_releases": 37,
         "code_churn_overall": 355,

--- a/tests/patches/829421.json
+++ b/tests/patches/829421.json
@@ -1,0 +1,15 @@
+{
+    "9f56d7e548f1": {
+        "changes_size": 21,
+        "code_churn_last_3_releases": 21,
+        "code_churn_overall": 110,
+        "developer_familiarity_last_3_releases": 0,
+        "developer_familiarity_overall": 0,
+        "modules_num": 1,
+        "reviewer_familiarity_last_3_releases": 4,
+        "reviewer_familiarity_overall": 11,
+        "source": "mercurial",
+        "test_changes_size": 0,
+        "url": "https://hg.mozilla.org/mozilla-central/rev/9f56d7e548f1"
+    }
+}

--- a/tests/patches/829421.json
+++ b/tests/patches/829421.json
@@ -1,5 +1,7 @@
 {
     "9f56d7e548f1": {
+        "changes_add": 3,
+        "changes_del": 1,
         "changes_size": 21,
         "code_churn_last_3_releases": 21,
         "code_churn_overall": 110,

--- a/tests/patches/843821.json
+++ b/tests/patches/843821.json
@@ -1,0 +1,28 @@
+{
+    "3c11909c216a": {
+        "changes_size": 129,
+        "code_churn_last_3_releases": 141,
+        "code_churn_overall": 879,
+        "developer_familiarity_last_3_releases": 12,
+        "developer_familiarity_overall": 124,
+        "modules_num": 1,
+        "reviewer_familiarity_last_3_releases": 0,
+        "reviewer_familiarity_overall": 0,
+        "source": "mercurial",
+        "test_changes_size": 0,
+        "url": "https://hg.mozilla.org/mozilla-central/rev/3c11909c216a"
+    },
+    "b2c38a3b59dc": {
+        "changes_size": 19,
+        "code_churn_last_3_releases": 8,
+        "code_churn_overall": 8,
+        "developer_familiarity_last_3_releases": 7,
+        "developer_familiarity_overall": 7,
+        "modules_num": 1,
+        "reviewer_familiarity_last_3_releases": 8,
+        "reviewer_familiarity_overall": 8,
+        "source": "mercurial",
+        "test_changes_size": 0,
+        "url": "https://hg.mozilla.org/mozilla-central/rev/b2c38a3b59dc"
+    }
+}

--- a/tests/patches/843821.json
+++ b/tests/patches/843821.json
@@ -1,5 +1,7 @@
 {
     "3c11909c216a": {
+        "changes_add": 39,
+        "changes_del": 7,
         "changes_size": 129,
         "code_churn_last_3_releases": 141,
         "code_churn_overall": 879,
@@ -13,6 +15,8 @@
         "url": "https://hg.mozilla.org/mozilla-central/rev/3c11909c216a"
     },
     "b2c38a3b59dc": {
+        "changes_add": 0,
+        "changes_del": 3,
         "changes_size": 19,
         "code_churn_last_3_releases": 8,
         "code_churn_overall": 8,

--- a/tests/patches/853033.json
+++ b/tests/patches/853033.json
@@ -1,0 +1,15 @@
+{
+    "bb210464e583": {
+        "changes_size": 18,
+        "code_churn_last_3_releases": 1,
+        "code_churn_overall": 4,
+        "developer_familiarity_last_3_releases": 1,
+        "developer_familiarity_overall": 1,
+        "modules_num": 1,
+        "reviewer_familiarity_last_3_releases": 0,
+        "reviewer_familiarity_overall": 0,
+        "source": "mercurial",
+        "test_changes_size": 0,
+        "url": "https://hg.mozilla.org/mozilla-central/rev/bb210464e583"
+    }
+}

--- a/tests/patches/853033.json
+++ b/tests/patches/853033.json
@@ -1,5 +1,7 @@
 {
     "bb210464e583": {
+        "changes_add": 1,
+        "changes_del": 1,
         "changes_size": 18,
         "code_churn_last_3_releases": 1,
         "code_churn_overall": 4,

--- a/tests/patches/859425.json
+++ b/tests/patches/859425.json
@@ -1,5 +1,7 @@
 {
     "5549afae23a7": {
+        "changes_add": 6,
+        "changes_del": 5,
         "changes_size": 31,
         "code_churn_last_3_releases": 30,
         "code_churn_overall": 79,

--- a/tests/patches/859425.json
+++ b/tests/patches/859425.json
@@ -1,0 +1,15 @@
+{
+    "5549afae23a7": {
+        "changes_size": 31,
+        "code_churn_last_3_releases": 30,
+        "code_churn_overall": 79,
+        "developer_familiarity_last_3_releases": 1,
+        "developer_familiarity_overall": 1,
+        "modules_num": 1,
+        "reviewer_familiarity_last_3_releases": 0,
+        "reviewer_familiarity_overall": 0,
+        "source": "mercurial",
+        "test_changes_size": 0,
+        "url": "https://hg.mozilla.org/mozilla-central/rev/5549afae23a7"
+    }
+}

--- a/tests/patches/901821.json
+++ b/tests/patches/901821.json
@@ -1,0 +1,15 @@
+{
+    "b43afcd4e347": {
+        "changes_size": 18,
+        "code_churn_last_3_releases": 152,
+        "code_churn_overall": 1088,
+        "developer_familiarity_last_3_releases": 23,
+        "developer_familiarity_overall": 115,
+        "modules_num": 1,
+        "reviewer_familiarity_last_3_releases": 0,
+        "reviewer_familiarity_overall": 0,
+        "source": "mercurial",
+        "test_changes_size": 0,
+        "url": "https://hg.mozilla.org/mozilla-central/rev/b43afcd4e347"
+    }
+}

--- a/tests/patches/901821.json
+++ b/tests/patches/901821.json
@@ -1,5 +1,7 @@
 {
     "b43afcd4e347": {
+        "changes_add": 1,
+        "changes_del": 1,
         "changes_size": 18,
         "code_churn_last_3_releases": 152,
         "code_churn_overall": 1088,

--- a/tests/patches/903475.json
+++ b/tests/patches/903475.json
@@ -1,0 +1,15 @@
+{
+    "d76cd808a5fc": {
+        "changes_size": 18,
+        "code_churn_last_3_releases": 3,
+        "code_churn_overall": 13,
+        "developer_familiarity_last_3_releases": 0,
+        "developer_familiarity_overall": 0,
+        "modules_num": 1,
+        "reviewer_familiarity_last_3_releases": 0,
+        "reviewer_familiarity_overall": 0,
+        "source": "mercurial",
+        "test_changes_size": 0,
+        "url": "https://hg.mozilla.org/mozilla-central/rev/d76cd808a5fc"
+    }
+}

--- a/tests/patches/903475.json
+++ b/tests/patches/903475.json
@@ -1,5 +1,7 @@
 {
     "d76cd808a5fc": {
+        "changes_add": 1,
+        "changes_del": 1,
         "changes_size": 18,
         "code_churn_last_3_releases": 3,
         "code_churn_overall": 13,

--- a/tests/patches/914034.json
+++ b/tests/patches/914034.json
@@ -1,0 +1,15 @@
+{
+    "a13edd3c49e7": {
+        "changes_size": 287,
+        "code_churn_last_3_releases": 27,
+        "code_churn_overall": 240,
+        "developer_familiarity_last_3_releases": 7,
+        "developer_familiarity_overall": 7,
+        "modules_num": 1,
+        "reviewer_familiarity_last_3_releases": 2,
+        "reviewer_familiarity_overall": 3,
+        "source": "mercurial",
+        "test_changes_size": 0,
+        "url": "https://hg.mozilla.org/mozilla-central/rev/a13edd3c49e7"
+    }
+}

--- a/tests/patches/914034.json
+++ b/tests/patches/914034.json
@@ -1,5 +1,7 @@
 {
     "a13edd3c49e7": {
+        "changes_add": 66,
+        "changes_del": 31,
         "changes_size": 287,
         "code_churn_last_3_releases": 27,
         "code_churn_overall": 240,

--- a/tests/test_patchanalysis.py
+++ b/tests/test_patchanalysis.py
@@ -38,6 +38,11 @@ class PatchAnalysisTest(MockTestCase):
         self.assertEqual(len(missed_warnings), 0)
         self.assertEqual(len(unexpected_warnings), 0)
 
+    def assertDictEqual(self, d1, d2, msg=None):
+        for k, v1 in d1.items():
+            self.assertIn(k, d2, msg)
+            self.assertEqual(v1, d2[k], msg)
+
     def assertEqualPatches(self, patches, bug_id):
         """
         Check patches are equals to local dumps
@@ -53,7 +58,7 @@ class PatchAnalysisTest(MockTestCase):
 
         # Keys can be int or str
         for k, patch_data in patches.items():
-            self.assertDictEqual(patch_data, local_patches[str(k)])
+            self.assertEqual(patch_data, local_patches[str(k)])
 
     @responses.activate
     def test_bug_analysis(self):


### PR DESCRIPTION
Hello @marco-c & @calixteman,

I need to display the changes additions & deletions in Shipit (as +XX/-YY for example).
Whatthepatch does not give directly this information, so i had to compute it.

Regarding the unit test, i put all the patches checks in separate files, more easily diffable than a Python inline dict (see the second commit).