### PR TITLE
Escape html elements in uplift comment parser

### DIFF
--- a/libmozdata/patchanalysis.py
+++ b/libmozdata/patchanalysis.py
@@ -750,6 +750,15 @@ def parse_uplift_comment(text, bug_id=None):
         if v != '':
             out[h].append(v)
 
+    # Remove html entities
+    html_escape_table = {
+        '&': '&amp;',
+        '"': '&quot;',
+        "'": '&apos;',
+        '>': '&gt;',
+        '<': '&lt;',
+    }
+    text = ''.join(html_escape_table.get(c, c) for c in text)
     lines = text.split('\n')
 
     # Build headers

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -104,6 +104,10 @@ class UtilsTest(unittest.TestCase):
         out = parse('https://developer.mozilla.org/en-US/docs/Web/API/Media_Streams_API/Constraints#Result')
         self.assertEqual(out, '<div class="no-header"><a href="https://developer.mozilla.org/en-US/docs/Web/API/Media_Streams_API/Constraints#Result" target="_blank">https://developer.mozilla.org/en-US/docs/Web/API/Media_Streams_API/Constraints#Result</a></div>')
 
+        # Html escaped
+        out = parse('Bug on <select/> element')
+        self.assertEqual(out, '<div class="no-header">Bug on &lt;select/&gt; element</div>')
+
         # Full comments
         for text_path in glob.glob('tests/uplift/*.txt'):
             with open(text_path, 'r') as text:


### PR DESCRIPTION
Hello @marco-c and @calixteman,

Some bugzilla uplift comments have html in them (duh.) so libmozdata needs to escape those characters to be properly displayed in the Shipit dashboard.

Thanks @sylvestre for reporting this bug.