### PR TITLE
Mercurial revision number is 40-digit hexa string

### DIFF
--- a/libmozdata/bugzilla.py
+++ b/libmozdata/bugzilla.py
@@ -289,21 +289,21 @@ class Bugzilla(Connection):
         for channel in channels:
             if channel in ['central', 'nightly']:
                 landing_patterns += [
-                    (re.compile('://hg.mozilla.org/mozilla-central/rev/([0-9a-z]+)'), channel),
-                    (re.compile('://hg.mozilla.org/mozilla-central/pushloghtml\?changeset=([0-9a-z]+)'), channel),
+                    (re.compile('://hg.mozilla.org/mozilla-central/rev/([0-9a-f]+)'), channel),
+                    (re.compile('://hg.mozilla.org/mozilla-central/pushloghtml\?changeset=([0-9a-f]+)'), channel),
                 ]
             elif channel == 'inbound':
-                landing_patterns += [(re.compile('://hg.mozilla.org/integration/mozilla-inbound/rev/([0-9a-z]+)'), 'inbound')]
+                landing_patterns += [(re.compile('://hg.mozilla.org/integration/mozilla-inbound/rev/([0-9a-f]+)'), 'inbound')]
             elif channel in ['release', 'beta', 'aurora']:
-                landing_patterns += [(re.compile('://hg.mozilla.org/releases/mozilla-' + channel + '/rev/([0-9a-z]+)'), channel)]
+                landing_patterns += [(re.compile('://hg.mozilla.org/releases/mozilla-' + channel + '/rev/([0-9a-f]+)'), channel)]
             elif channel == 'esr':
                 # Use last esr version
                 versions = libmozdata.versions.get(True)
                 if 'esr' not in versions:
                     raise Exception('Missing esr version')
-                landing_patterns += [(re.compile('://hg.mozilla.org/releases/mozilla-esr' + str(versions['esr']) + '/rev/([0-9a-z]+)'), channel)]
+                landing_patterns += [(re.compile('://hg.mozilla.org/releases/mozilla-esr' + str(versions['esr']) + '/rev/([0-9a-f]+)'), channel)]
             elif channel == 'fx-team':
-                landing_patterns += [(re.compile('://hg.mozilla.org/integration/fx-team/rev/([0-9a-z]+)'), 'inbound')]
+                landing_patterns += [(re.compile('://hg.mozilla.org/integration/fx-team/rev/([0-9a-f]+)'), 'inbound')]
             else:
                 raise Exception('Unexpected channel: ' + channel)
 


### PR DESCRIPTION
Avoid an issue in parsing comment 8 in bug 1333576.
For information, the format of short revision number is described here: https://www.mercurial-scm.org/wiki/RevisionNumber