### PR TITLE
Use bugzilla.mozilla.org directly instead of bugzil.la

### DIFF
--- a/libmozdata/bugzilla.py
+++ b/libmozdata/bugzilla.py
@@ -200,9 +200,9 @@ class Bugzilla(Connection):
     @staticmethod
     def get_links(bugids):
         if isinstance(bugids, six.string_types) or isinstance(bugids, int):
-            return 'https://bugzil.la/' + str(bugids)
+            return 'https://bugzilla.mozilla.org/' + str(bugids)
         else:
-            return ['https://bugzil.la/' + str(bugid) for bugid in bugids]
+            return ['https://bugzilla.mozilla.org/' + str(bugid) for bugid in bugids]
 
     @staticmethod
     def follow_dup(bugids, only_final=True):

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -687,10 +687,10 @@ class User(MockTestCase):
 class BugLinksTest(unittest.TestCase):
 
     def test_bugid(self):
-        self.assertEqual(bugzilla.Bugzilla.get_links('12345'), 'https://bugzil.la/12345')
-        self.assertEqual(bugzilla.Bugzilla.get_links(12345), 'https://bugzil.la/12345')
-        self.assertEqual(bugzilla.Bugzilla.get_links(['12345', '123456']), ['https://bugzil.la/12345', 'https://bugzil.la/123456'])
-        self.assertEqual(bugzilla.Bugzilla.get_links([12345, 123456]), ['https://bugzil.la/12345', 'https://bugzil.la/123456'])
+        self.assertEqual(bugzilla.Bugzilla.get_links('12345'), 'https://bugzilla.mozilla.org/12345')
+        self.assertEqual(bugzilla.Bugzilla.get_links(12345), 'https://bugzilla.mozilla.org/12345')
+        self.assertEqual(bugzilla.Bugzilla.get_links(['12345', '123456']), ['https://bugzilla.mozilla.org/12345', 'https://bugzilla.mozilla.org/123456'])
+        self.assertEqual(bugzilla.Bugzilla.get_links([12345, 123456]), ['https://bugzilla.mozilla.org/12345', 'https://bugzilla.mozilla.org/123456'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The latter is not run by mozilla, and is currently down.