### PR TITLE
[WIP] Add test for new uplift request comment format.

### DIFF
--- a/tests/test_patchanalysis.py
+++ b/tests/test_patchanalysis.py
@@ -571,6 +571,10 @@ class PatchAnalysisTest(MockTestCase):
         info = patchanalysis.uplift_info(1416872, 'beta')
         self.assertEqual(info['release_delta'], timedelta(9, 54694))
 
+        # New uplift request comment format
+        info = patchanalysis.uplift_info(1510281, 'beta')
+        self.assertIsNotNone(info['uplift_comment'])
+
     @responses.activate
     def test_patch_info(self):
         base_versions = {'nightly': 52, 'aurora': 51, 'beta': 50, 'release': 49, 'esr': 45}

--- a/tests/uplift/1510281.html
+++ b/tests/uplift/1510281.html
@@ -1,0 +1,28 @@
+<pre class="comment-text " id="ct-4">Comment on <span class=""><a href="/attachment.cgi?id=9027925" name="attach_9027925" title="Bug 1510281 - Use a private and isolated context for search suggestions. r=mkaply!">attachment 9027925</a> <a href="/attachment.cgi?id=9027925&amp;action=edit" title="Bug 1510281 - Use a private and isolated context for search suggestions. r=mkaply!">[details]</a></span>
+<a class="bz_bug_link
+          bz_status_RESOLVED bz_closed" title="RESOLVED FIXED - Use a private and isolated context for search suggestions" href="/show_bug.cgi?id=1510281">Bug 1510281</a> - Use a private and isolated context for search suggestions. r=mkaply!
+
+[Beta/Release Uplift Approval Request]
+
+Feature/Bug causing the regression: None
+
+User impact if declined: Fetching search suggestions may store/share unexpected cookies. This is an old defect but being privacy-related we want it sooner than later.
+
+Is this code covered by automated tests?: Yes
+
+Has the fix been verified in Nightly?: No
+
+Needs manual test from QE?: Yes
+
+If yes, steps to reproduce: In a new profile:
+1. Type about:preferences#privacy in the address bar, wait for search suggestions to appear, confirm with Enter
+2. Open Manage Data
+3. Check there's no Google cookie
+
+List of other uplifts needed: None
+
+Risk to taking this patch: Low
+
+Why is the change risky/not risky? (and alternatives if risky): The code changes are simple
+
+String changes made/needed: none</pre>

--- a/tests/uplift/1510281.txt
+++ b/tests/uplift/1510281.txt
@@ -1,0 +1,27 @@
+Comment on attachment 9027925 [details]
+Bug 1510281 - Use a private and isolated context for search suggestions. r=mkaply!
+
+[Beta/Release Uplift Approval Request]
+
+Feature/Bug causing the regression: None
+
+User impact if declined: Fetching search suggestions may store/share unexpected cookies. This is an old defect but being privacy-related we want it sooner than later.
+
+Is this code covered by automated tests?: Yes
+
+Has the fix been verified in Nightly?: No
+
+Needs manual test from QE?: Yes
+
+If yes, steps to reproduce: In a new profile:
+1. Type about:preferences#privacy in the address bar, wait for search suggestions to appear, confirm with Enter
+2. Open Manage Data
+3. Check there's no Google cookie
+
+List of other uplifts needed: None
+
+Risk to taking this patch: Low
+
+Why is the change risky/not risky? (and alternatives if risky): The code changes are simple
+
+String changes made/needed: none


### PR DESCRIPTION
As a follow-up to #131, I'd like to add a test using the new uplift request comment format.

However, this test currently fails with:

```
======================================================================
ERROR: test_uplift_info (test_patchanalysis.PatchAnalysisTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "<string>", line 3, in wrapper
  File "/workspace/libmozdata/tests/test_patchanalysis.py", line 575, in test_uplift_info
    info = patchanalysis.uplift_info(1510281, 'beta')
  File "/workspace/libmozdata/libmozdata/patchanalysis.py", line 626, in uplift_info
    release_date = versions.getCloserRelease(uplift_request_date)[1]
  File "/workspace/libmozdata/libmozdata/versions.py", line 162, in getCloserRelease
    return __getCloserDate(date, list(__version_dates.items()) + list(__stability_version_dates.items()), negative)
  File "/workspace/libmozdata/libmozdata/versions.py", line 143, in __getCloserDate
    raise Exception('No future release found')
Exception: No future release found

----------------------------------------------------------------------
```

The error comes from this method:

https://github.com/mozilla/libmozdata/blob/1a39a3b60d4198e96def8e1117513fa715342194/libmozdata/versions.py#L133-L144

and is probably due to the fact that the latest release in `versions_dates` is `('61.0.1', datetime.datetime(2018, 7, 5, 7, 0, tzinfo=<UTC>)`, i.e. *before* the uplift comment, which was posted today (2018-11-28).