### PR TITLE
Switch to Buildhub2 (#166)

### DIFF
--- a/libmozdata/buildhub.py
+++ b/libmozdata/buildhub.py
@@ -12,7 +12,7 @@ import requests
 
 SEARCH_URL = os.getenv(
     "BUILDHUB_SEARCH_URL",
-    "https://buildhub.prod.mozaws.net/v1/buckets/build-hub/collections/releases/search",
+    "https://buildhub.moz.tools/api/search",
 )
 
 


### PR DESCRIPTION
This switches the buildhub module to use Buildhub2 for build information.

Fixes #166.