### PR TITLE
Request all pages from Phabricator API

### DIFF
--- a/libmozdata/phabricator.py
+++ b/libmozdata/phabricator.py
@@ -666,6 +666,19 @@ class PhabricatorAPI(object):
         assert "result" in data
         return data["result"]
 
+    def request_all_pages(self, path, **payload):
+        """
+        Send requests to Phabricator API and create a generator to return data from all pages.
+        The limit in the API is 100 results per request. This function will return all results.
+        """
+        next = True
+        while next:
+            result = self.request(path, **payload)
+            for row in result["data"]:
+                yield row
+
+            payload["after"] = next = result["cursor"]["after"]
+
     def load_patches_stack(self, diff_id, diff=None):
         """
         Load a stack of patches with related commits, to reach a given Phabricator Diff

--- a/mozdata.ini-TEMPLATE
+++ b/mozdata.ini-TEMPLATE
@@ -18,6 +18,9 @@ token =
 URL = https://bugzilla.mozilla.org
 token =
 
+[Phabricator]
+token =
+
 [Allizgub]
 URL = https://bugzilla-dev.allizom.org
 token =

--- a/tests/test_phabricator.py
+++ b/tests/test_phabricator.py
@@ -3,7 +3,6 @@ import unittest
 
 from libmozdata import config
 from libmozdata.phabricator import PhabricatorAPI, PhabricatorPatch
-from tests.auto_mock import MockTestCase
 
 
 class PhabricatorTest(unittest.TestCase):

--- a/tests/test_phabricator.py
+++ b/tests/test_phabricator.py
@@ -1,7 +1,9 @@
 import pickle
 import unittest
 
-from libmozdata.phabricator import PhabricatorPatch
+from libmozdata import config
+from libmozdata.phabricator import PhabricatorAPI, PhabricatorPatch
+from tests.auto_mock import MockTestCase
 
 
 class PhabricatorTest(unittest.TestCase):
@@ -15,3 +17,16 @@ class PhabricatorTest(unittest.TestCase):
 
     def test_pickle_phabricatorpatch(self):
         pickle.dumps(PhabricatorPatch("123", "PHID-DIFF-xxx", "", "rev", []))
+
+
+class PhabricatorRequestTest(unittest.TestCase):
+    def test_request_all_pages(self):
+        token = config.get("Phabricator", "token", "")
+        phab = PhabricatorAPI(token)
+
+        constraints = {"createdStart": 1648600370, "createdEnd": 1648686770}
+        data = phab.request_all_pages(
+            "differential.revision.search", constraints=constraints
+        )
+
+        self.assertEqual(len(list(data)), 115)


### PR DESCRIPTION
The limit in Phabricator API is [100 results per request](https://phabricator.services.mozilla.com/conduit/method/differential.revision.search/#paging). This PR adds a function that creates a generator to return data from all pages.

- [ ] We need to add a Phabricator token to the CI to pass on the new test.