### PR TITLE
Use receiver instead of buildTargetPHID in phabricator API call harbormaster.sendmessage

### DIFF
--- a/libmozdata/phabricator.py
+++ b/libmozdata/phabricator.py
@@ -489,7 +489,7 @@ class PhabricatorAPI(object):
         assert isinstance(state, BuildState)
         return self.request(
             "harbormaster.sendmessage",
-            buildTargetPHID=build_target_phid,
+            receiver=build_target_phid,
             type=state.value,
             unit=unit,
             lint=lint,


### PR DESCRIPTION
This fixes the issue `Conduit API error ERR-CONDUIT-CORE : Call omits required "receiver" parameter. Specify the PHID of the object you want to send a message to`.

The phabricator prod instance was recently updated, making `buildTargetPHID` a deprecated parameter, and replaced by `receiver`. More info there https://phabricator.services.mozilla.com/conduit/method/harbormaster.sendmessage/