### PR TITLE
[release_calendar] Support the new table structure on the wiki page

### DIFF
--- a/libmozdata/release_calendar.py
+++ b/libmozdata/release_calendar.py
@@ -33,39 +33,65 @@ def get_calendar():
     if _CALENDAR is not None:
         return _CALENDAR
 
+    table = None
     html = requests.get(CALENDAR_URL).text.encode("ascii", errors="ignore")
     parser = WikiParser(tables=[0])
     try:
         parser.feed(html)
     except StopIteration:
         table = parser.get_tables()[0]
-        if [
-            "Quarter",
-            "Soft Freeze",
-            "Merge Date",
-            "Nightly",
-            "Beta",
-            "Release Date",
-            "Release",
-            "ESR",
-        ] != table[0]:
-            raise InvalidWiki("Column headers are wrong")
 
-        _CALENDAR = []
-        for row in table[1:]:
-            row = row[1:]
-            _CALENDAR.append(
-                {
-                    "soft freeze": utils.get_date_ymd(row[0]),
-                    "merge": utils.get_date_ymd(row[1]),
-                    "central": get_versions(row[2])[0][0],
-                    "beta": get_versions(row[3])[0][0],
-                    "release date": utils.get_date_ymd(row[4]),
-                    "release": get_versions(row[5])[0][0],
-                    "esr": get_versions(row[6]),
-                }
-            )
-        return _CALENDAR
+    if table is None:
+        raise InvalidWiki("No table found")
+
+    # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+    # FIXME: remove the following after dropping the old table from the wiki
+    if [
+        "Quarter",
+        "Soft Freeze",
+        "Merge Date",
+        "Nightly",
+        "Beta",
+        "Release Date",
+        "Release",
+        "ESR",
+    ] == table[0]:
+        parser = WikiParser(tables=[1])
+        try:
+            parser.feed(html)
+        except StopIteration:
+            table = parser.get_tables()[0]
+    # <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+    if [
+        "Quarter",
+        "Fx Release",
+        "Nightly begins",
+        "Nightly Soft Freeze*",
+        "Beta begins",
+        "Releases on",
+        "Corresponding ESR",
+    ] != table[0]:
+        raise InvalidWiki("Column headers are wrong")
+
+    _CALENDAR = []
+    for i in range(1, len(table) - 2):
+        release = table[i]
+        beta = table[i + 1]
+        nightly = table[i + 2]
+
+        _CALENDAR.append(
+            {
+                "soft freeze": utils.get_date_ymd(beta[3]),
+                "merge": utils.get_date_ymd(beta[4]),
+                "central": get_versions(nightly[1])[0][0],
+                "beta": get_versions(beta[1])[0][0],
+                "release date": utils.get_date_ymd(release[5]),
+                "release": get_versions(release[1])[0][0],
+                "esr": get_versions(release[6]),
+            }
+        )
+    return _CALENDAR
 
 
 def get_next_release_date():


### PR DESCRIPTION
The wiki page currently has two versions of the "Future branch dates" table, the first with the old structure and the second with the new structure. The old structure table will be dropped soon.