### PR TITLE
Added `autoland` channel to `get_landing_patterns`

### DIFF
--- a/libmozdata/bugzilla.py
+++ b/libmozdata/bugzilla.py
@@ -404,6 +404,15 @@ class Bugzilla(BugzillaBase):
                         "inbound",
                     )
                 ]
+            elif channel == "autoland":
+                landing_patterns += [
+                    (
+                        re.compile(
+                            r"://hg.mozilla.org/integration/autoland/rev/([0-9a-f]+)"
+                        ),
+                        "autoland",
+                    )
+                ]
             else:
                 raise Exception("Unexpected channel: " + channel)
 


### PR DESCRIPTION
Adds `autoland` as a channel to `get_landing_patterns`. Resolves [#2431](https://github.com/mozilla/bugbot/pull/2413) in BugBot.