### PR TITLE
Added retry for requests made to Phabricator API

### DIFF
--- a/libmozdata/phabricator.py
+++ b/libmozdata/phabricator.py
@@ -12,6 +12,7 @@ from urllib.parse import urlencode, urlparse
 
 import hglib
 import requests
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
 
 from . import config
 
@@ -654,6 +655,11 @@ class PhabricatorAPI(object):
             data = [data]
         return data
 
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_fixed(2),
+        retry=retry_if_exception_type(requests.exceptions.ConnectionError),
+    )
     def request(self, path, **payload):
         """
         Send a request to Phabricator API

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ requests-futures>=0.9.8
 requests[security]>=2.7.0
 setuptools>=28.6.1
 six>=1.10.0
+tenacity>=9.0.0
 whatthepatch>=0.0.4


### PR DESCRIPTION
Currently, we may encounter `requests.exceptions.ConnectionError` when sending a request to the Phabricator API (i.e. `('Connection aborted.', ConnectionResetError(54, 'Connection reset by peer')`). 

I have added a retry decorate to the `request()` function in `phabricator.py` to potentially avoid encountering this error, especially for tasks such as the `inline_comments_data_collection.py` in [Bugbug](https://github.com/mozilla/bugbug).