### PR TITLE
Add pytz to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 icalendar>=3.10
 python-dateutil>=2.5.2
 python-hglib>=2.6.1
+pytz==2024.2
 requests-futures>=0.9.8
 requests[security]>=2.7.0
 setuptools>=28.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 icalendar>=3.10
 python-dateutil>=2.5.2
 python-hglib>=2.6.1
-pytz==2024.2
+pytz>=2022
 requests-futures>=0.9.8
 requests[security]>=2.7.0
 setuptools>=28.6.1


### PR DESCRIPTION
The pipeline for [this PR](https://github.com/mozilla/libmozdata/pull/249) failed because of this missing requirements, I think.