### PR TITLE
Expose Lando public CommitMap API

### DIFF
--- a/libmozdata/lando.py
+++ b/libmozdata/lando.py
@@ -3,6 +3,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from collections import namedtuple
+from urllib.parse import urljoin
+
 import requests
 
 from . import config
@@ -91,3 +94,60 @@ class LandoWarnings(object):
 
         if len(current_warnings):
             return self.del_warnings(current_warnings)
+
+
+# Represent the commit in both mercurial & git sources, using full hashes
+CommitMap = namedtuple("CommitMap", "git_hash, hg_hash")
+
+
+class LandoMissingCommit(Exception):
+    """
+    Raised when a commit is not available on Lando CommitMap API
+    """
+
+
+class LandoCommitMapAPI:
+    """
+    Anonymous API calls on Lando API to convert mercurial <=> git commits
+    """
+
+    def __init__(self, api_url="https://lando.moz.tools/api/"):
+        self.api_url = api_url
+        assert self.api_url.endswith("/"), "Lando API url must end with a /"
+        self.USER_AGENT = config.get("User-Agent", "name", required=True)
+
+    def request(self, method, repository, revision) -> CommitMap:
+        """
+        Call a conversion method on Lando API and return a CommitMap object
+        with both full hashes
+        """
+        url = urljoin(self.api_url, f"{method}/{repository}/{revision}")
+        resp = requests.get(
+            url,
+            headers={
+                "User-Agent": self.USER_AGENT,
+            },
+        )
+        if not resp.ok:
+            if resp.status_code == 404:
+                raise LandoMissingCommit(
+                    f"No commit found for {method} {revision}@{repository}"
+                )
+
+            raise Exception(
+                f"Failed to resolve {method} {revision}@{repository}: {resp.text}"
+            )
+
+        return CommitMap(**resp.json())
+
+    def git2hg(self, revision: str, repository="firefox") -> CommitMap:
+        """
+        Convert a git hash into a mercurial one
+        """
+        return self.request("git2hg", repository, revision)
+
+    def hg2git(self, revision: str, repository="firefox") -> CommitMap:
+        """
+        Convert a mercurial hash into a git one
+        """
+        return self.request("hg2git", repository, revision)

--- a/tests/test_lando.py
+++ b/tests/test_lando.py
@@ -2,7 +2,12 @@ import unittest
 
 import responses
 
-from libmozdata.lando import LandoWarnings
+from libmozdata.lando import (
+    CommitMap,
+    LandoCommitMapAPI,
+    LandoMissingCommit,
+    LandoWarnings,
+)
 
 MOCK_LANDO_API_URL = "http://api.lando.test"
 MOCK_LANDO_TOKEN = "Some Test Token"
@@ -139,6 +144,110 @@ class Test_LandoWarnings(unittest.TestCase):
                 str(ex),
                 f"Failed to delete warning with ID {MOCK_WARNINGS_ID} with error 400:\nDelete error",
             )
+
+
+class Test_LandoCommitMap(unittest.TestCase):
+    @responses.activate
+    def test_git2hg(self):
+        responses.add(
+            responses.GET,
+            f"{MOCK_LANDO_API_URL}/git2hg/test_repo/1234abcde",
+            json={"git_hash": "1234abcde1234abcde", "hg_hash": "56789xxxx"},
+        )
+
+        mock_lando = LandoCommitMapAPI(MOCK_LANDO_API_URL + "/")
+
+        self.assertEqual(
+            mock_lando.git2hg("1234abcde", repository="test_repo"),
+            CommitMap("1234abcde1234abcde", "56789xxxx"),
+        )
+
+    @responses.activate
+    def test_hg2git(self):
+        responses.add(
+            responses.GET,
+            f"{MOCK_LANDO_API_URL}/hg2git/test_repo/1234abcde",
+            json={"hg_hash": "1234abcde1234abcde", "git_hash": "56789xxxx"},
+        )
+
+        mock_lando = LandoCommitMapAPI(MOCK_LANDO_API_URL + "/")
+
+        self.assertEqual(
+            mock_lando.hg2git("1234abcde", repository="test_repo"),
+            CommitMap("56789xxxx", "1234abcde1234abcde"),
+        )
+
+    @responses.activate
+    def test_git2hg_missing(self):
+        responses.add(
+            responses.GET,
+            f"{MOCK_LANDO_API_URL}/git2hg/test_repo/1234abcde",
+            status=404,
+        )
+
+        mock_lando = LandoCommitMapAPI(MOCK_LANDO_API_URL + "/")
+
+        with self.assertRaises(LandoMissingCommit) as e:
+            self.assertEqual(mock_lando.git2hg("1234abcde", repository="test_repo"))
+
+        self.assertEqual(
+            str(e.exception), "No commit found for git2hg 1234abcde@test_repo"
+        )
+
+    @responses.activate
+    def test_hg2git_missing(self):
+        responses.add(
+            responses.GET,
+            f"{MOCK_LANDO_API_URL}/hg2git/test_repo/1234abcde",
+            status=404,
+        )
+
+        mock_lando = LandoCommitMapAPI(MOCK_LANDO_API_URL + "/")
+
+        with self.assertRaises(LandoMissingCommit) as e:
+            self.assertEqual(mock_lando.hg2git("1234abcde", repository="test_repo"))
+
+        self.assertEqual(
+            str(e.exception), "No commit found for hg2git 1234abcde@test_repo"
+        )
+
+    @responses.activate
+    def test_git2hg_failure(self):
+        responses.add(
+            responses.GET,
+            f"{MOCK_LANDO_API_URL}/git2hg/test_repo/1234abcde",
+            status=500,
+            json={"error": "System error"},
+        )
+
+        mock_lando = LandoCommitMapAPI(MOCK_LANDO_API_URL + "/")
+
+        with self.assertRaises(Exception) as e:
+            self.assertEqual(mock_lando.git2hg("1234abcde", repository="test_repo"))
+
+        self.assertEqual(
+            str(e.exception),
+            'Failed to resolve git2hg 1234abcde@test_repo: {"error": "System error"}',
+        )
+
+    @responses.activate
+    def test_hg2git_failure(self):
+        responses.add(
+            responses.GET,
+            f"{MOCK_LANDO_API_URL}/hg2git/test_repo/1234abcde",
+            status=500,
+            json={"error": "System error"},
+        )
+
+        mock_lando = LandoCommitMapAPI(MOCK_LANDO_API_URL + "/")
+
+        with self.assertRaises(Exception) as e:
+            self.assertEqual(mock_lando.hg2git("1234abcde", repository="test_repo"))
+
+        self.assertEqual(
+            str(e.exception),
+            'Failed to resolve hg2git 1234abcde@test_repo: {"error": "System error"}',
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Refs https://github.com/mozilla/code-review/issues/2982

This allows libmozdata users to resolve:
- git commit into mercurial ones
- mercurial commit into git ones

A `CommitMap` named tuple is returned to always get both full hashes, as the user may send a short hash to Lando.