### PR TITLE
Fix isort error by running on Python 3.13

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -54,7 +54,7 @@ tasks:
         deadline: { $fromNow: "1 hour" }
         payload:
           maxRunTime: 3600
-          image: python:3.9
+          image: python:3.13
           env:
             CODECOV_TOKEN: 2074f917-03ff-4f90-bafd-1fb186e42216
           command:

--- a/libmozdata/FileStats.py
+++ b/libmozdata/FileStats.py
@@ -4,7 +4,7 @@
 
 import argparse
 import numbers
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pprint import pprint
 
 from . import config, modules, utils
@@ -36,7 +36,8 @@ class FileStats(object):
         )
         self.utc_ts_from = (
             utils.get_timestamp(
-                datetime.utcfromtimestamp(utc_ts) + timedelta(-self.max_days)
+                datetime.fromtimestamp(utc_ts, tz=timezone.utc)
+                + timedelta(-self.max_days)
             )
             if isinstance(utc_ts, numbers.Number) and utc_ts > 0
             else None

--- a/libmozdata/config.py
+++ b/libmozdata/config.py
@@ -78,7 +78,6 @@ def set_config(conf):
 
 
 def get(section, option, default=None, type=str, required=False):
-    global __config
     value = __config.get(section, option, default=default, type=type)
     if required:
         assert value is not None, f"Option {option} in section {section} is not set"
@@ -86,5 +85,4 @@ def get(section, option, default=None, type=str, required=False):
 
 
 def set_default_value(section, option, value):
-    global __config
     __config.set_default(section, option, value)

--- a/libmozdata/patchanalysis.py
+++ b/libmozdata/patchanalysis.py
@@ -4,7 +4,7 @@ import numbers
 import re
 import warnings
 import weakref
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import whatthepatch
 
@@ -665,7 +665,9 @@ def bug_analysis(bug, uplift_channel=None, author_cache={}, reviewer_cache={}):
                     hgmozilla.RawRevision.get_revision(obj["channel"], rev),
                     author_names,
                     reviewers,
-                    utils.as_utc(datetime.utcfromtimestamp(obj["creation_date"])),
+                    utils.as_utc(
+                        datetime.fromtimestamp(obj["creation_date"], tz=timezone.utc)
+                    ),
                 )
             )
     else:
@@ -976,7 +978,9 @@ def get_patch_info(
     bug_pattern = re.compile(r"[\t ]*[Bb][Uu][Gg][\t ]*([0-9]+)")
 
     def handler_revision(json, data):
-        data["date"] = utils.as_utc(datetime.utcfromtimestamp(json["pushdate"][0]))
+        data["date"] = utils.as_utc(
+            datetime.fromtimestamp(json["pushdate"][0], tz=timezone.utc)
+        )
         data["backedout"] = json.get("backedoutby", "") != ""
         m = bug_pattern.search(json["desc"])
         if not m or m.group(1) != data["bugid"]:

--- a/libmozdata/utils.py
+++ b/libmozdata/utils.py
@@ -7,7 +7,7 @@ import math
 import operator
 import os.path
 import random
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from itertools import count
 
 import dateutil.parser
@@ -44,7 +44,7 @@ def get_timestamp(dt):
         int: the corresponding timestamp
     """
     if isinstance(dt, six.string_types):
-        dt = datetime.utcnow() if dt == "now" else get_date_ymd(dt)
+        dt = datetime.now(timezone.utc) if dt == "now" else get_date_ymd(dt)
     return int(calendar.timegm(dt.timetuple()))
 
 
@@ -57,7 +57,7 @@ def get_date_from_timestamp(ts):
     Returns:
         datetime.datetime: the corresponding datetime in UTC tz
     """
-    return datetime.utcfromtimestamp(ts).replace(tzinfo=pytz.utc)
+    return datetime.fromtimestamp(ts, tz=pytz.utc)
 
 
 def get_date_ymd(dt):
@@ -75,13 +75,13 @@ def get_date_ymd(dt):
         return as_utc(dt)
 
     if dt == "today":
-        today = datetime.utcnow()
+        today = datetime.now(timezone.utc)
         return pytz.utc.localize(datetime(today.year, today.month, today.day))
     elif dt == "tomorrow":
-        tomorrow = datetime.utcnow() + timedelta(1)
+        tomorrow = datetime.now(timezone.utc) + timedelta(1)
         return pytz.utc.localize(datetime(tomorrow.year, tomorrow.month, tomorrow.day))
     elif dt == "yesterday":
-        yesterday = datetime.utcnow() - timedelta(1)
+        yesterday = datetime.now(timezone.utc) - timedelta(1)
         return pytz.utc.localize(
             datetime(yesterday.year, yesterday.month, yesterday.day)
         )
@@ -131,7 +131,7 @@ def get_now_timestamp():
     Returns:
         int: timestamp for now
     """
-    return get_timestamp(datetime.utcnow())
+    return get_timestamp(datetime.now(timezone.utc))
 
 
 def is64(cpu_name):
@@ -327,10 +327,12 @@ def get_params_for_url(params):
         "?"
         + "&".join(
             [
-                quote(name) + "=" + quote(str(value))
-                if not isinstance(value, list)
-                else "&".join(
-                    [quote(name) + "=" + quote(str(intValue)) for intValue in value]
+                (
+                    quote(name) + "=" + quote(str(value))
+                    if not isinstance(value, list)
+                    else "&".join(
+                        [quote(name) + "=" + quote(str(intValue)) for intValue in value]
+                    )
                 )
                 for name, value in sorted(params.items(), key=lambda p: p[0])
                 if value is not None


### PR DESCRIPTION
Fixes #287 

The bumped isort and black pre-commit hooks require Python >= 3.10, so CI on python:3.9 failed at hook install. Run CI on python:3.13 instead.

Also fix issues that surface on the newer toolchain/runtime:
- Remove unused `global __config` declarations flagged by flake8 (F824)
- Apply black's reformatting of get_params_for_url
- Replace deprecated datetime.utcnow()/utcfromtimestamp() with timezone-aware equivalents (deprecated since Python 3.12)