### PR TITLE
Temporarily disable the release owners test

### DIFF
--- a/tests/test_release_owners.py
+++ b/tests/test_release_owners.py
@@ -9,6 +9,10 @@ from libmozdata.wiki_parser import InvalidWiki
 
 
 class ReleaseOwnersTest(unittest.TestCase):
+    # Temporarily disabled: wiki.mozilla.org is behind a JavaScript bot
+    # challenge, so the release owners table can no longer be fetched over
+    # plain HTTP. See https://github.com/mozilla/libmozdata/issues/289
+    @unittest.skip("Wiki is behind a JS bot challenge (issue #289)")
     def test_ro(self):
         # The wiki hosting release owners table may provide 403 to CI tasks
         try:


### PR DESCRIPTION
Mitigates #289, to fix the CI for now.

wiki.mozilla.org is now served behind a Fastly JavaScript bot challenge, so the release owners table can no longer be fetched over plain HTTP and the test fails. Skip it until we find a working way to retrieve the data.
