### PR TITLE
Retry all Phabricator API calls upon 50x HTTP error codes

### DIFF
--- a/libmozdata/phabricator.py
+++ b/libmozdata/phabricator.py
@@ -210,7 +210,7 @@ class PhabricatorAPI(object):
     Phabricator Rest API client
     """
 
-    def __init__(self, api_key, url=MOZILLA_PHABRICATOR_PROD, max_retries=3):
+    def __init__(self, api_key, url=MOZILLA_PHABRICATOR_PROD, max_retries=5):
         self.USER_AGENT = config.get("User-Agent", "name", required=True)
         self.api_key = api_key
         self.url = url

--- a/libmozdata/phabricator.py
+++ b/libmozdata/phabricator.py
@@ -7,6 +7,7 @@ import collections
 import enum
 import json
 import logging
+import math
 import time
 from functools import cached_property
 from urllib.parse import urlencode, urlparse
@@ -676,11 +677,12 @@ class PhabricatorAPI(object):
                 data=urlencode({"params": json.dumps(payload), "output": "json"}),
             )
             if response.status_code >= 500:
-                # Retry after a while on 50x
+                # Retry after a while on 50x using exponential backoff
+                backoff = math.exp(nb_try)
                 logger.info(
-                    f"Phabricator failed with status code {response.status_code}, retrying in 5 seconds..."
+                    f"Phabricator failed with status code {response.status_code}, retrying in {backoff:.1f} seconds..."
                 )
-                time.sleep(5)
+                time.sleep(backoff)
             else:
                 # Stop retrying on the first successful try or other HTTP errors
                 break

--- a/libmozdata/phabricator.py
+++ b/libmozdata/phabricator.py
@@ -7,6 +7,7 @@ import collections
 import enum
 import json
 import logging
+import time
 from functools import cached_property
 from urllib.parse import urlencode, urlparse
 
@@ -208,11 +209,17 @@ class PhabricatorAPI(object):
     Phabricator Rest API client
     """
 
-    def __init__(self, api_key, url=MOZILLA_PHABRICATOR_PROD):
+    def __init__(self, api_key, url=MOZILLA_PHABRICATOR_PROD, max_retries=3):
         self.USER_AGENT = config.get("User-Agent", "name", required=True)
         self.api_key = api_key
         self.url = url
         assert self.url.endswith("/api/"), "Phabricator API must end with /api/"
+
+        # Number of API calls retries on 50x before raising an error
+        self.max_retries = max_retries
+        assert (
+            isinstance(self.max_retries, int) and self.max_retries > 0
+        ), "Invalid max_retries parameter"
 
     @cached_property
     def user(self):
@@ -236,7 +243,7 @@ class PhabricatorAPI(object):
         diff_id=None,
         revision_phid=None,
         output_cursor=False,
-        **params
+        **params,
     ):
         """
         Find details of differential diffs from a Differential diff or revision
@@ -661,12 +668,24 @@ class PhabricatorAPI(object):
         # Add api token to payload
         payload["__conduit__"] = {"token": self.api_key}
 
-        # Run POST request on api
-        response = requests.post(
-            self.url + path,
-            headers=self.get_header(),
-            data=urlencode({"params": json.dumps(payload), "output": "json"}),
-        )
+        # Run POST request on api, retrying on 50x errors
+        for nb_try in range(1, self.max_retries + 1):
+            response = requests.post(
+                self.url + path,
+                headers=self.get_header(),
+                data=urlencode({"params": json.dumps(payload), "output": "json"}),
+            )
+            if response.status_code >= 500:
+                # Retry after a while on 50x
+                logger.info(
+                    f"Phabricator failed with status code {response.status_code}, retrying in 5 seconds..."
+                )
+                time.sleep(5)
+            else:
+                # Stop retrying on the first successful try or other HTTP errors
+                break
+
+        # Raise immediate 40x errors or out-of-retries 50x
         response.raise_for_status()
 
         # Check response


### PR DESCRIPTION
Refs https://github.com/mozilla/code-review/issues/3489


[Tenacity](https://tenacity.readthedocs.io/en/latest/) was not already included, and I don't think this use-case warrants a new dependency on libmozdata.
Also I wanted to control the number of retries.