### PR TITLE
Bug 2068637 - add support for first-public-parent

### DIFF
--- a/libmozdata/phabricator.py
+++ b/libmozdata/phabricator.py
@@ -19,7 +19,9 @@ HGMO_JSON_REV_URL_TEMPLATE = "https://hg.mozilla.org/mozilla-central/json-rev/{}
 MOZILLA_PHABRICATOR_PROD = "https://phabricator.services.mozilla.com/api/"
 
 PhabricatorPatch = collections.namedtuple(
-    "PhabricatorPatch", "id, phid, patch, base_revision, commits, merged"
+    "PhabricatorPatch",
+    "id, phid, patch, base_revision, commits, merged, first_public_parent",
+    defaults=[None],
 )
 
 logger = logging.getLogger(__name__)
@@ -705,13 +707,24 @@ class PhabricatorAPI(object):
                 diff_phid=diff["phid"], attachments={"commits": True}
             )
             commits = diffs[0]["attachments"]["commits"].get("commits", [])
+            query_diffs = self.request("differential.querydiffs", ids=[diff["id"]])
+            properties = query_diffs.get(str(diff["id"]), {}).get("properties", {})
+            first_public_parent = properties.get("moz-phab:first-public-parent")
+            if isinstance(first_public_parent, dict):
+                first_public_parent = first_public_parent.get("node")
             logger.info(
                 "Adding patch #{} to stack ({})".format(
                     diff["id"], "merged" if merged else "non-merged"
                 )
             )
             return PhabricatorPatch(
-                diff["id"], diff["phid"], patch, diff["baseRevision"], commits, merged
+                diff["id"],
+                diff["phid"],
+                patch,
+                diff["baseRevision"],
+                commits,
+                merged,
+                first_public_parent,
             )
 
         # Load full diff when not provided by user

--- a/libmozdata/phabricator.py
+++ b/libmozdata/phabricator.py
@@ -714,7 +714,7 @@ class PhabricatorAPI(object):
                 logger.warn("Diff %s has no local:commits property", diff["id"])
 
             first_public_parent = None
-            # local:commits is keyed by the local commit node , which may differ from
+            # local:commits is keyed by the local commit node, which may differ from
             # the public commit identifier exposed by Phabricator's commits attachment
             # hence iterating over values (there is only one in the dict but key unknown).
             for local_commit in local_commits.values():

--- a/libmozdata/phabricator.py
+++ b/libmozdata/phabricator.py
@@ -709,9 +709,18 @@ class PhabricatorAPI(object):
             commits = diffs[0]["attachments"]["commits"].get("commits", [])
             query_diffs = self.request("differential.querydiffs", ids=[diff["id"]])
             properties = query_diffs.get(str(diff["id"]), {}).get("properties", {})
-            first_public_parent = properties.get("moz-phab:first-public-parent")
-            if isinstance(first_public_parent, dict):
-                first_public_parent = first_public_parent.get("node")
+            local_commits = properties.get("local:commits") or {}
+            if not local_commits:
+                logger.warn("Diff %s has no local:commits property", diff["id"])
+
+            first_public_parent = None
+            # local:commits is keyed by the local commit node , which may differ from
+            # the public commit identifier exposed by Phabricators commits attachment
+            # hence iterating over values (there is only one in the dict but key unknown).
+            for local_commit in local_commits.values():
+                first_public_parent = local_commit.get("firstPublicParent")
+                if first_public_parent:
+                    break
             logger.info(
                 "Adding patch #{} to stack ({})".format(
                     diff["id"], "merged" if merged else "non-merged"

--- a/libmozdata/phabricator.py
+++ b/libmozdata/phabricator.py
@@ -715,7 +715,7 @@ class PhabricatorAPI(object):
 
             first_public_parent = None
             # local:commits is keyed by the local commit node , which may differ from
-            # the public commit identifier exposed by Phabricators commits attachment
+            # the public commit identifier exposed by Phabricator's commits attachment
             # hence iterating over values (there is only one in the dict but key unknown).
             for local_commit in local_commits.values():
                 first_public_parent = local_commit.get("firstPublicParent")


### PR DESCRIPTION
Tested with local phabricator/[patched mozphab](https://phabricator.services.mozilla.com/D324588) with local smoke test:
<img width="600" height="311" alt="Screenshot 2026-09-09 at 18 10 54" src="https://github.com/user-attachments/assets/6d7d7e7b-e4fb-4fa4-ad79-255205dfa807" />
<img width="632" height="150" alt="Screenshot 2026-09-09 at 18 12 08" src="https://github.com/user-attachments/assets/91f5ee0b-77a7-4f3e-a044-a38127ce572f" />

(base rev and first public parent in this case are expected to be the same as there is just one revision before this one and it is public)